### PR TITLE
chore: minor spelling fix

### DIFF
--- a/polynomial-regression/index.js
+++ b/polynomial-regression/index.js
@@ -155,7 +155,7 @@ function toNormalizedTensors(xyData, order) {
 //   epochs: How many epochs to train for.
 //   learningRate: Learning rate.
 //
-// Returns: An Array consiting of the following:
+// Returns: An Array consisting of the following:
 //   The trained keras Model instance.
 //   xPowerMeans: Arithmetic means of the powers of x, from order `1` to
 //      order `order`


### PR DESCRIPTION
Simply fixes a minor spelling error in the polynomial regression tfjs example.